### PR TITLE
fix(SSLProviderIssue): Update @Value configurations in CertificateService

### DIFF
--- a/wizard-core/src/main/java/eu/gaiax/wizard/core/service/ssl/CertificateService.java
+++ b/wizard-core/src/main/java/eu/gaiax/wizard/core/service/ssl/CertificateService.java
@@ -52,7 +52,7 @@ public class CertificateService {
     private final ScheduleService scheduleService;
     private final VaultService vaultService;
 
-    public CertificateService(VaultService vaultService, DomainService domainService, ParticipantRepository participantRepository, ScheduleService scheduleService, @Value("wizard.sslProvider") String sslProvider) {
+    public CertificateService(VaultService vaultService, DomainService domainService, ParticipantRepository participantRepository, ScheduleService scheduleService, @Value("${wizard.sslProvider}") String sslProvider) {
         this.vaultService = vaultService;
         this.domainService = domainService;
         this.participantRepository = participantRepository;


### PR DESCRIPTION
This change will resolve below issue,
java.lang.IllegalArgumentException: No ACME provider found for wizard.sslProvider